### PR TITLE
Add step to escaping extra curly braces in mutation model output

### DIFF
--- a/fuzzy/handlers/attacks/gpt_fuzzer/handler.py
+++ b/fuzzy/handlers/attacks/gpt_fuzzer/handler.py
@@ -106,7 +106,7 @@ class GPTFuzzerAttackHandler(BaseAttackTechniqueHandler[GPTFuzzerAttackHandlerEx
 
         logger.info("Finished running the action")
         async with self._borrow(self._model) as llm:
-            changed_prompt = sub(r'(?<!{INSERT_PROMPT_HERE)([{}])(?!INSERT_PROMPT_HERE})', # Escape the extra curly braces to avoid consistent KeyError
+            changed_prompt = sub(r'(?<!{INSERT_PROMPT_HERE)([{}])(?!INSERT_PROMPT_HERE})',
                                  r'\1\1',
                                  variation_response.response).format(INSERT_PROMPT_HERE=prompt) #type:ignore
             response = await llm.generate(changed_prompt, **self._extra)

--- a/fuzzy/handlers/attacks/gpt_fuzzer/handler.py
+++ b/fuzzy/handlers/attacks/gpt_fuzzer/handler.py
@@ -107,7 +107,7 @@ class GPTFuzzerAttackHandler(BaseAttackTechniqueHandler[GPTFuzzerAttackHandlerEx
         logger.info("Finished running the action")
         async with self._borrow(self._model) as llm:
             changed_prompt = sub(r'(?<!{INSERT_PROMPT_HERE)([{}])(?!INSERT_PROMPT_HERE})', # Escape the extra curly braces to avoid consistent KeyError
-                                 r'\\\1',
+                                 r'\1\1',
                                  variation_response.response).format(INSERT_PROMPT_HERE=prompt) #type:ignore
             response = await llm.generate(changed_prompt, **self._extra)
             result = AttackResultEntry(original_prompt=prompt,


### PR DESCRIPTION
### Desired Outcome

The mutation model sometimes generated extra curly braces in the prompt, resulting in a consistent KeyError/ValueError when trying to format the string using {INSERT_PROMPT_HERE} placeholders. This little 1 row change prevents this situation from happening at all.

### Implemented Changes

Added a little regex in the GPTFuzzerAttackHandler that doubles all curly brace characters that are not in a '{INSERT_PROMPT_HERE}' sequence.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [x] A follow-up issue to update official docs has been filed here: #22 
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
