### PR TITLE
Fix error caused by new transformers version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ motor = "^3.6"
 pydantic = "^2.5.3"
 aiofiles = "^23.2.1"
 aiohttp = {version = "^3.9.1", extras = ["speedups"]}
-transformers = "^4.37.2"
+transformers = "4.51.3"
 sentence-transformers = "^2.6.1"
 fschat = "^0.2.36"
 pygad = "^3.3.1"


### PR DESCRIPTION
### Desired Outcome

In the pyproject.toml file, transformers uses the most recent version. However, transformers 4.52.3 caused fuzzyai to crash for me after a fresh install via `pip install fuzzyai` with the following log

```
Traceback (most recent call last):
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/cli.py", line 17, in <module>
    from fuzzyai.fuzzer import Fuzzer
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/fuzzer.py", line 13, in <module>
    from fuzzyai.handlers.attacks.base import BaseAttackTechniqueHandler, attack_handler_fm
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/handlers/attacks/__init__.py", line 1, in <module>
    from .actor_attack.handler import ActorAttackHandler
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/handlers/attacks/actor_attack/handler.py", line 11, in <module>
    from fuzzyai.handlers.attacks.base import (BaseAttackTechniqueHandler, BaseAttackTechniqueHandlerException,
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/handlers/attacks/base.py", line 16, in <module>
    from fuzzyai.handlers.classifiers.base import BaseClassifier
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/handlers/classifiers/__init__.py", line 6, in <module>
    from .disapproval.handler import DisapprovalClassifier
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/handlers/classifiers/disapproval/handler.py", line 6, in <module>
    from fuzzyai.handlers.text_analyzer import DisapprovalAnalysis, ZeroShotAnalyzer
  File "/Users/me/GitHub/FuzzyAI/src/fuzzyai/handlers/text_analyzer.py", line 7, in <module>
    from transformers import pipeline
  File "<frozen importlib._bootstrap>", line 1075, in _handle_fromlist
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/utils/import_utils.py", line 2045, in __getattr__
    module = self._get_module(self._class_to_module[name])
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/utils/import_utils.py", line 2075, in _get_module
    raise e
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/utils/import_utils.py", line 2073, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/Users/me/.pyenv/versions/3.10.13/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/pipelines/__init__.py", line 49, in <module>
    from .audio_classification import AudioClassificationPipeline
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/pipelines/audio_classification.py", line 21, in <module>
    from .base import Pipeline, build_pipeline_init_args
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/pipelines/base.py", line 70, in <module>
    from ..modeling_utils import PreTrainedModel
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/modeling_utils.py", line 64, in <module>
    from .integrations.tensor_parallel import (
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/integrations/tensor_parallel.py", line 723, in <module>
    class ParallelInterface(MutableMapping):
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/integrations/tensor_parallel.py", line 733, in ParallelInterface
    "colwise": ColwiseParallel(),
  File "/Users/me/GitHub/FuzzyAI/venv/lib/python3.10/site-packages/transformers/integrations/tensor_parallel.py", line 465, in __init__
    self.input_layouts = (input_layouts or Replicate(),)
NameError: name 'Replicate' is not defined
```

The error results from this line of code

```
if is_torch_greater_or_equal("2.5") and _torch_distributed_available:
    from torch.distributed.tensor import DTensor, Placement, Replicate, Shard
```

since fuzzyai uses torch 2.2.2, Replicate is not imported and thus the error results.

### Implemented Changes

Pinning the transformers version to 4.51.3 solves the issue. Alternatively, torch could be pinned to something >= 2.5 but I assume that upgrading torch that much might have more side effects.